### PR TITLE
add remaining time function to lambda context

### DIFF
--- a/src/pytest_stepfunctions/services/aws_lambda.py
+++ b/src/pytest_stepfunctions/services/aws_lambda.py
@@ -18,6 +18,9 @@ class LambdaContext:
     )
     aws_request_id: str = "da658bd3-2d6f-4e7b-8ec2-937234644fdc"
 
+    def get_remaining_time_in_millis(self) -> int:
+        return 5
+
 
 class AWSLambdaRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:


### PR DESCRIPTION
We need this additional function to test the idempotency feature of powertools on lambdas.

https://docs.powertools.aws.dev/lambda/python/latest/utilities/idempotency/#testing-with-dynamodb-local